### PR TITLE
BOOK-1939: (feat) Add aria label for the bookings types and apply ref…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Inicialmente al hacer el fork se heredaron los tags del repo original. Estos fue
 
 El proceso utilizado para el versionado es hacerlo manualmente con los siguientes pasos:
 
-1. Generar el nuevo tag con `git tag vX.X.X` ej: (`git tag v0.1.0`)
-2. Pushear: `git push origin vX.X.X`
+1. Actualizar `package.json` con la nueva `"version"` y hacer commit y push
+2. Generar el nuevo tag con `git tag vX.X.X` ej: (`git tag v0.1.0`)
+3. Pushear tag con `git push origin vX.X.X`
+4. Actualizar `package.json` en el proyecto donde se quiere consumir este proyecto con: `"pikaday": "zityhub/Pikaday#vX.X.X"` y hacer un `yarn`
 
 *** OJO es importante tener en cuenta que si en algún momento se hiciese una sincronización con la rama master del repo original habría que evitar que se sincronizasen los tags porque sino habría colisión con los del proyecto actual. Para ello habría que utilizar:
 ```

--- a/pikaday.js
+++ b/pikaday.js
@@ -353,14 +353,20 @@
 
             // Add "aria-label"
             
-            if (opts.dayClasses.includes('zh-booking')) {
-                ariaLabel += ' con reserva'
-            } else if (opts.dayClasses.includes('zh-office')) {
-                ariaLabel += ' oficina'
-            } else if (opts.dayClasses.includes('zh-remote')) {
-                ariaLabel += ' remoto'
-            } else if (opts.dayClasses.includes('zh-not-available')) {
-                ariaLabel += ' no disponible'
+            const mapClassesToAriaLabel = {
+                'zh-office': ' oficina',
+                'zh-remote': ' remoto',
+                'zh-not-available': ' no disponible',
+                'zh-booking': ' con reserva de',
+                'zh-booking-desk': ' desk',
+                'zh-booking-meeting': ' meeting',
+                'zh-booking-parking': ' parking',
+            };
+            
+            for (const [dayClass, dayClassAriaLabel] of Object.entries(mapClassesToAriaLabel)) {
+                if (opts.dayClasses.includes(dayClass)) {
+                    ariaLabel += dayClassAriaLabel;
+                }
             }
         }
 


### PR DESCRIPTION
Esta PR cierra [#BOOK-1939](https://zityhub.atlassian.net/browse/BOOK-1939)

### Descripción

- (Post Deploy) Analizar si meter tests de aria-label para cada dot del tipo de reserva
- Añade los aria-label correspondientes al tipo de reserva que tiene cada día

### Aceptación

- [ ] Revisión de código

### Información extra

- Una vez aprobada esta PR y la de la booking app haré la subida del versionado del fork y así ya en la booking app puedo actualizar su versión en el package.json
